### PR TITLE
Fix Tk widget initialization order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Test_AI_Codex_Copilot
+
+This project provides a small Tkinter GUI for recording response templates in an SQLite database.
+
+## Running the app
+1. Initialize the database by executing `python db.py`.
+2. Launch the GUI (the "server") with `python gui.py`.

--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,13 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 import db
 
+# Placeholder globals. Actual widgets are created in main() after the Tk
+# root window is initialized.
+categorie_var = None
+titre_var = None
+texte_text = None
+lien_var = None
+
 def submit_form():
     categorie = categorie_var.get().strip()
     titre = titre_var.get().strip()
@@ -26,6 +33,12 @@ def main():
     root = tk.Tk()
     root.title("Ajout de réponse")
 
+    global categorie_var, titre_var, texte_text, lien_var
+    categorie_var = tk.StringVar(root)
+    titre_var = tk.StringVar(root)
+    texte_text = tk.Text(root, height=10, width=40)
+    lien_var = tk.StringVar(root)
+
     main_frame = ttk.Frame(root, padding=10)
     main_frame.grid(sticky=(tk.W, tk.E, tk.N, tk.S))
 
@@ -48,12 +61,6 @@ def main():
     submit_btn.grid(column=0, row=4, columnspan=2, pady=5)
 
     root.mainloop()
-
-
-categorie_var = tk.StringVar()
-titre_var = tk.StringVar()
-texte_text = tk.Text(height=10, width=40)
-lien_var = tk.StringVar()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- create placeholder globals before any Tk widgets are built
- initialize `StringVar` objects and `Text` widget after creating `root`
- ensure all widgets use `root` as master
- document how to start the GUI
- clarify comment about placeholder globals

## Testing
- `python -m py_compile gui.py db.py`
- `python gui.py` *(fails: no $DISPLAY)*


------
https://chatgpt.com/codex/tasks/task_e_684bf3277294833281143b4f2c66d682